### PR TITLE
Add basement dashboard tab with TOU energy cost tracking

### DIFF
--- a/lovelace-dashboards/dashboard.yaml
+++ b/lovelace-dashboards/dashboard.yaml
@@ -3,4 +3,5 @@ title: Dashboard
 views:
   - !include views/hvac.yaml
   - !include views/office.yaml
+  - !include views/basement.yaml
   - !include views/qtip.yaml

--- a/lovelace-dashboards/views/basement.yaml
+++ b/lovelace-dashboards/views/basement.yaml
@@ -1,0 +1,116 @@
+---
+title: Basement
+path: basement
+icon: mdi:home-floor-b
+cards:
+  # Air Quality
+  - type: gauge
+    entity: sensor.basement_aqi
+    name: Air Quality Index
+    min: 0
+    max: 300
+    severity:
+      green: 0
+      yellow: 51
+      red: 101
+
+  - type: custom:mini-graph-card
+    entities:
+      - entity: sensor.basement_air_sensor_carbon_dioxide
+        name: CO2
+    name: CO2 Level
+    hours_to_show: 24
+    points_per_hour: 2
+    line_width: 2
+    show:
+      icon: false
+
+  - type: glance
+    title: Air Quality Details
+    entities:
+      - entity: sensor.basement_air_sensor_pm2_5
+        name: PM2.5
+      - entity: sensor.basement_air_sensor_voc_index
+        name: VOC
+      - entity: sensor.basement_air_sensor_temperature
+        name: Temp
+      - entity: sensor.basement_air_sensor_humidity
+        name: Humidity
+    columns: 4
+
+  - type: entities
+    title: Air Filter
+    entities:
+      - entity: fan.basement_air_filter
+        name: Air Filter
+      - entity: input_boolean.basement_filter_auto_mode
+        name: Auto Mode
+    state_color: true
+
+  # Jayden's Computer
+  - type: entities
+    title: Jayden's Computer
+    state_color: true
+    entities:
+      - entity: switch.jaydens_computer
+        name: Power
+      - entity: sensor.jaydens_computer_power
+        name: Current Power
+      - entity: select.jaydens_computer_energy_meter
+        name: Active Tariff
+
+  - type: glance
+    title: This Month's Usage (kWh)
+    columns: 4
+    entities:
+      - entity: sensor.jaydens_computer_energy_total
+        name: Total
+      - entity: sensor.jaydens_computer_energy_meter_peak
+        name: Peak
+      - entity: sensor.jaydens_computer_energy_meter_mid_peak
+        name: Mid-Peak
+      - entity: sensor.jaydens_computer_energy_meter_off_peak
+        name: Off-Peak
+
+  - type: entities
+    title: This Month's Cost
+    entities:
+      - entity: sensor.jaydens_computer_energy_cost
+        name: Total Cost
+
+  - type: entities
+    title: TOU Rates
+    entities:
+      - entity: input_number.electricity_rate_peak
+        name: Peak (5pm–9pm)
+      - entity: input_number.electricity_rate_mid_peak
+        name: Mid-Peak (6am–5pm, 9pm–12am)
+      - entity: input_number.electricity_rate_off_peak
+        name: Off-Peak (12am–6am)
+
+  - type: statistics-graph
+    title: Daily Energy Use (Last 30 Days)
+    entities:
+      - sensor.jaydens_computer_energy
+    days_to_show: 30
+    period: day
+    stat_types:
+      - change
+    chart_type: bar
+
+  # HVAC
+  - type: thermostat
+    entity: climate.faikin_basement_mqtt_hvac
+    name: Basement HVAC
+
+  # Laundry Leak Sensor
+  - type: entities
+    title: Laundry Leak Sensor
+    state_color: true
+    entities:
+      - entity: binary_sensor.basement_leak_sensor_water_leak
+        name: Water Leak
+      - entity: binary_sensor.basement_leak_sensor_battery_low
+        name: Battery Low
+      - entity: sensor.basement_leak_sensor_battery
+        name: Battery Level

--- a/packages/energy.yaml
+++ b/packages/energy.yaml
@@ -1,0 +1,149 @@
+---
+# Energy Cost Tracking
+# Tracks per-device energy usage with time-of-use (TOU) tariffs.
+#
+# TOU schedule (local time):
+#   off_peak: 00:00–06:00  ($0.0805/kWh)
+#   mid_peak: 06:00–17:00  ($0.1409/kWh)
+#   peak:     17:00–21:00  ($0.1610/kWh)
+#   mid_peak: 21:00–24:00  ($0.1409/kWh)
+
+input_number:
+  electricity_rate_peak:
+    name: "Electricity Rate - Peak"
+    min: 0.0
+    max: 2.0
+    step: 0.0001
+    unit_of_measurement: "USD/kWh"
+    icon: mdi:cash
+
+  electricity_rate_mid_peak:
+    name: "Electricity Rate - Mid-Peak"
+    min: 0.0
+    max: 2.0
+    step: 0.0001
+    unit_of_measurement: "USD/kWh"
+    icon: mdi:cash
+
+  electricity_rate_off_peak:
+    name: "Electricity Rate - Off-Peak"
+    min: 0.0
+    max: 2.0
+    step: 0.0001
+    unit_of_measurement: "USD/kWh"
+    icon: mdi:cash
+
+utility_meter:
+  jaydens_computer_energy_meter:
+    name: "Jayden's Computer Energy Meter"
+    source: sensor.jaydens_computer_energy
+    cycle: monthly
+    tariffs:
+      - peak
+      - mid_peak
+      - off_peak
+
+template:
+  - sensor:
+      - name: "Jayden's Computer Energy Cost"
+        unique_id: jaydens_computer_energy_cost
+        unit_of_measurement: "USD"
+        state_class: total
+        icon: mdi:cash
+        state: >
+          {% set peak_rate = states('input_number.electricity_rate_peak') | float(0) %}
+          {% set mid_rate  = states('input_number.electricity_rate_mid_peak') | float(0) %}
+          {% set off_rate  = states('input_number.electricity_rate_off_peak') | float(0) %}
+          {% set peak_kwh = states('sensor.jaydens_computer_energy_meter_peak') | float(0) %}
+          {% set mid_kwh  = states('sensor.jaydens_computer_energy_meter_mid_peak') | float(0) %}
+          {% set off_kwh  = states('sensor.jaydens_computer_energy_meter_off_peak') | float(0) %}
+          {{ (peak_kwh * peak_rate + mid_kwh * mid_rate + off_kwh * off_rate) | round(2) }}
+        availability: >
+          {{ states('sensor.jaydens_computer_energy_meter_peak') not in ['unknown', 'unavailable', 'none']
+             and states('sensor.jaydens_computer_energy_meter_mid_peak') not in ['unknown', 'unavailable', 'none']
+             and states('sensor.jaydens_computer_energy_meter_off_peak') not in ['unknown', 'unavailable', 'none'] }}
+
+      - name: "Jayden's Computer Energy Total"
+        unique_id: jaydens_computer_energy_total
+        unit_of_measurement: "kWh"
+        device_class: energy
+        state_class: total
+        icon: mdi:flash
+        state: >
+          {% set peak_kwh = states('sensor.jaydens_computer_energy_meter_peak') | float(0) %}
+          {% set mid_kwh  = states('sensor.jaydens_computer_energy_meter_mid_peak') | float(0) %}
+          {% set off_kwh  = states('sensor.jaydens_computer_energy_meter_off_peak') | float(0) %}
+          {{ (peak_kwh + mid_kwh + off_kwh) | round(2) }}
+        availability: >
+          {{ states('sensor.jaydens_computer_energy_meter_peak') not in ['unknown', 'unavailable', 'none']
+             and states('sensor.jaydens_computer_energy_meter_mid_peak') not in ['unknown', 'unavailable', 'none']
+             and states('sensor.jaydens_computer_energy_meter_off_peak') not in ['unknown', 'unavailable', 'none'] }}
+
+automation:
+  - id: set_default_electricity_rates
+    alias: "Set Default Electricity Rates"
+    description: "Initialize TOU rates to defaults if unset"
+    triggers:
+      - trigger: homeassistant
+        event: start
+    actions:
+      - if:
+          - condition: numeric_state
+            entity_id: input_number.electricity_rate_peak
+            below: 0.0001
+        then:
+          - action: input_number.set_value
+            target:
+              entity_id: input_number.electricity_rate_peak
+            data:
+              value: 0.1610
+      - if:
+          - condition: numeric_state
+            entity_id: input_number.electricity_rate_mid_peak
+            below: 0.0001
+        then:
+          - action: input_number.set_value
+            target:
+              entity_id: input_number.electricity_rate_mid_peak
+            data:
+              value: 0.1409
+      - if:
+          - condition: numeric_state
+            entity_id: input_number.electricity_rate_off_peak
+            below: 0.0001
+        then:
+          - action: input_number.set_value
+            target:
+              entity_id: input_number.electricity_rate_off_peak
+            data:
+              value: 0.0805
+
+  - id: electricity_tariff_schedule
+    alias: "Switch Electricity Tariff"
+    description: "Switch utility meter tariff based on time of day"
+    mode: single
+    triggers:
+      - trigger: time
+        at: "00:00:00"
+      - trigger: time
+        at: "06:00:00"
+      - trigger: time
+        at: "17:00:00"
+      - trigger: time
+        at: "21:00:00"
+      - trigger: homeassistant
+        event: start
+    actions:
+      - variables:
+          tariff: >
+            {% set h = now().hour %}
+            {% if h < 6 %}off_peak
+            {% elif h < 17 %}mid_peak
+            {% elif h < 21 %}peak
+            {% else %}mid_peak
+            {% endif %}
+      - action: select.select_option
+        target:
+          entity_id: select.jaydens_computer_energy_meter
+        data:
+          option: "{{ tariff | trim }}"


### PR DESCRIPTION
## Summary
- New **Basement** dashboard tab with AQI gauge, CO2 graph, air-quality glance, air filter controls, basement HVAC thermostat, and laundry leak sensor (`binary_sensor.basement_leak_sensor_water_leak` — device is registered to the Laundry Room area). AQI/filter cards mirror the Office tab.
- New **Jayden's Computer** panel showing the smart switch, current power draw, active tariff, monthly kWh broken out by tariff, monthly cost in USD, editable rate helpers, and a 30-day daily-usage bar graph.
- New `packages/energy.yaml`:
  - Three rate helpers (`input_number.electricity_rate_peak/mid_peak/off_peak`) seeded on HA start to `0.1610 / 0.1409 / 0.0805` if unset.
  - `utility_meter.jaydens_computer_energy_meter` (monthly cycle, three tariffs) sourced from `sensor.jaydens_computer_energy`.
  - Template sensors for total monthly kWh and total monthly cost (`Σ kWh_tariff × rate_tariff`).
  - Automation `Switch Electricity Tariff` fires at 00:00 / 06:00 / 17:00 / 21:00 and on HA start, computing the active tariff from `now().hour` and calling `select.select_option`.

TOU schedule:
| Window | Tariff | Rate |
|---|---|---|
| 00:00–06:00 | off_peak | $0.0805 |
| 06:00–17:00 | mid_peak | $0.1409 |
| 17:00–21:00 | peak     | $0.1610 |
| 21:00–24:00 | mid_peak | $0.1409 |

## Test plan
- [ ] Basement tab renders all sections without missing-entity warnings
- [ ] AQI gauge, CO2 graph, air-quality glance, and air-filter cards behave the same as the Office tab
- [ ] `select.jaydens_computer_energy_meter` reflects the correct tariff after HA restart
- [ ] At 17:00 local time, active tariff switches to `peak`; at 21:00, back to `mid_peak`
- [ ] After non-zero monthly accumulation, cost sensor ≈ Σ tariff_kWh × tariff_rate
- [ ] Editing a rate helper updates the cost sensor live
- [ ] Laundry leak sensor card reflects state of `binary_sensor.basement_leak_sensor_water_leak`