### PR TITLE
Fix basement dashboard energy entity refs, remove TOU Rates card

### DIFF
--- a/lovelace-dashboards/views/basement.yaml
+++ b/lovelace-dashboards/views/basement.yaml
@@ -63,7 +63,7 @@ cards:
     title: This Month's Usage (kWh)
     columns: 4
     entities:
-      - entity: sensor.jaydens_computer_energy_total
+      - entity: sensor.jayden_s_computer_energy_total
         name: Total
       - entity: sensor.jaydens_computer_energy_meter_peak
         name: Peak
@@ -75,18 +75,8 @@ cards:
   - type: entities
     title: This Month's Cost
     entities:
-      - entity: sensor.jaydens_computer_energy_cost
+      - entity: sensor.jayden_s_computer_energy_cost
         name: Total Cost
-
-  - type: entities
-    title: TOU Rates
-    entities:
-      - entity: input_number.electricity_rate_peak
-        name: Peak (5pm–9pm)
-      - entity: input_number.electricity_rate_mid_peak
-        name: Mid-Peak (6am–5pm, 9pm–12am)
-      - entity: input_number.electricity_rate_off_peak
-        name: Off-Peak (12am–6am)
 
   - type: statistics-graph
     title: Daily Energy Use (Last 30 Days)


### PR DESCRIPTION
## Summary
- The "This Month's Usage" and "This Month's Cost" cards were showing **Entity not found** because the template sensor names contain an apostrophe (`Jayden's Computer Energy Cost` / `… Total`). HA slugifies that to `sensor.jayden_s_computer_energy_*` (with `_s_`), not `sensor.jaydens_*`. Updated the two dashboard refs to match the actual entity_ids.
- Removed the **TOU Rates** entities card per request.

## Notes
- The friendly names ("Jayden's Computer Energy Cost"/"… Total") are unchanged; only the dashboard entity_id strings were wrong.
- The MQTT source sensor uses `jaydens_*` (no apostrophe in its registered name) which is why the inconsistency wasn't visible at first glance.

## Test plan
- [ ] Reload Lovelace; confirm "This Month's Usage (kWh)" Total tile shows a numeric value, not "Entity not found"
- [ ] "This Month's Cost" card shows USD value
- [ ] TOU Rates card is gone