### PR TITLE
Replace master HVAC toggle with per-unit automation controls

### DIFF
--- a/lovelace-dashboards/hvac-control.yaml
+++ b/lovelace-dashboards/hvac-control.yaml
@@ -10,8 +10,14 @@ views:
       - type: entities
         title: Automation Control
         entities:
-          - entity: input_boolean.hvac_automation_enabled
-            name: HVAC Automation
+          - entity: input_boolean.living_room_hvac_automation
+            name: Living Room Automation
+          - entity: input_boolean.master_hvac_automation
+            name: Master Bedroom Automation
+          - entity: input_boolean.basement_hvac_automation
+            name: Basement Automation
+          - entity: input_boolean.guest_hvac_automation
+            name: Guest Bedroom Automation
           - entity: input_boolean.vacation_mode
             name: Vacation Mode
           - entity: binary_sensor.sleep_schedule
@@ -44,19 +50,6 @@ views:
       - type: thermostat
         entity: climate.faikin_guest_mqtt_hvac
         name: Guest Bedroom
-
-      # Air Quality & Sensors
-      - type: entities
-        title: Air Quality & System Info
-        entities:
-          - entity: sensor.main_floor_aqi
-            name: Main Floor Air Quality
-          - entity: sensor.hvac_learning_heat_time
-            name: Learning Heat Time
-          - entity: sensor.hvac_learning_cool_time
-            name: Learning Cool Time
-          - entity: sensor.basement_hvac_ac_target
-            name: Basement AC Target
 
       # System Overview
       - type: entities

--- a/lovelace-dashboards/views/hvac.yaml
+++ b/lovelace-dashboards/views/hvac.yaml
@@ -7,8 +7,14 @@ cards:
   - type: entities
     title: Automation Control
     entities:
-      - entity: input_boolean.hvac_automation_enabled
-        name: HVAC Automation
+      - entity: input_boolean.living_room_hvac_automation
+        name: Living Room Automation
+      - entity: input_boolean.master_hvac_automation
+        name: Master Bedroom Automation
+      - entity: input_boolean.basement_hvac_automation
+        name: Basement Automation
+      - entity: input_boolean.guest_hvac_automation
+        name: Guest Bedroom Automation
       - entity: input_boolean.vacation_mode
         name: Vacation Mode
       - entity: binary_sensor.sleep_schedule
@@ -42,19 +48,6 @@ cards:
     entity: climate.faikin_guest_mqtt_hvac
     name: Guest Bedroom
 
-  # Air Quality & Sensors
-  - type: entities
-    title: Air Quality & System Info
-    entities:
-      - entity: sensor.main_floor_aqi
-        name: Main Floor Air Quality
-      - entity: sensor.hvac_learning_heat_time
-        name: Learning Heat Time
-      - entity: sensor.hvac_learning_cool_time
-        name: Learning Cool Time
-      - entity: sensor.basement_hvac_ac_target
-        name: Basement AC Target
-
   # System Overview
   - type: entities
     title: All Climate Controls
@@ -63,4 +56,3 @@ cards:
       - entity: climate.faikin_master_mqtt_hvac
       - entity: climate.faikin_basement_mqtt_hvac
       - entity: climate.faikin_guest_mqtt_hvac
-

--- a/packages/controls.yaml
+++ b/packages/controls.yaml
@@ -37,3 +37,7 @@ binary_sensor:
     name: "Sleep Schedule"
     after: "22:30"
     before: "07:00"
+  - platform: tod
+    name: "Sleep Temperature Active"
+    after: "23:30"
+    before: "06:00"

--- a/packages/hvac.yaml
+++ b/packages/hvac.yaml
@@ -9,8 +9,17 @@
 # ============================================================================
 
 input_boolean:
-  hvac_automation_enabled:
-    name: "HVAC Automation Enabled"
+  living_room_hvac_automation:
+    name: "Living Room HVAC Automation"
+    icon: mdi:hvac
+  master_hvac_automation:
+    name: "Master Bedroom HVAC Automation"
+    icon: mdi:hvac
+  basement_hvac_automation:
+    name: "Basement HVAC Automation"
+    icon: mdi:hvac
+  guest_hvac_automation:
+    name: "Guest Bedroom HVAC Automation"
     icon: mdi:hvac
 
 # ============================================================================
@@ -37,19 +46,23 @@ automation:
         entity_id: input_boolean.vacation_mode
         id: vacation_mode
 
-      # Priority 3 & 4: Sleep/Awake schedule
+      # Priority 3 & 4: Sleep temperature schedule (1-hour buffer from sleep schedule)
       - trigger: state
-        entity_id: binary_sensor.sleep_schedule
+        entity_id: binary_sensor.sleep_temperature_active
         to: "on"
         id: sleep_start
       - trigger: state
-        entity_id: binary_sensor.sleep_schedule
+        entity_id: binary_sensor.sleep_temperature_active
         to: "off"
         id: awake_start
 
-      # Automation enabled
+      # Per-unit automation enabled
       - trigger: state
-        entity_id: input_boolean.hvac_automation_enabled
+        entity_id:
+          - input_boolean.living_room_hvac_automation
+          - input_boolean.master_hvac_automation
+          - input_boolean.basement_hvac_automation
+          - input_boolean.guest_hvac_automation
         to: "on"
         id: automation_enabled
 
@@ -60,11 +73,6 @@ automation:
           - input_number.awake_temperature
           - input_number.away_temperature
         id: temperature_changed
-
-    conditions:
-      - condition: state
-        entity_id: input_boolean.hvac_automation_enabled
-        state: "on"
 
     actions:
       # Add delay for temperature changes to avoid rapid updates
@@ -85,20 +93,44 @@ automation:
                 entity_id: sensor.main_floor_aqi
                 above: 99
             sequence:
-              # Turn on fan mode for units with air filters
-              - action: climate.set_hvac_mode
-                target:
-                  entity_id:
-                    - climate.faikin_living_mqtt_hvac
-                    - climate.faikin_guest_mqtt_hvac
-                data:
-                  hvac_mode: fan
+              # Fan mode for units with air filters
+              - if:
+                  - condition: state
+                    entity_id: input_boolean.living_room_hvac_automation
+                    state: "on"
+                then:
+                  - action: climate.set_hvac_mode
+                    target:
+                      entity_id: climate.faikin_living_mqtt_hvac
+                    data:
+                      hvac_mode: fan
+              - if:
+                  - condition: state
+                    entity_id: input_boolean.guest_hvac_automation
+                    state: "on"
+                then:
+                  - action: climate.set_hvac_mode
+                    target:
+                      entity_id: climate.faikin_guest_mqtt_hvac
+                    data:
+                      hvac_mode: fan
               # Turn off other units to save energy
-              - action: climate.turn_off
-                target:
-                  entity_id:
-                    - climate.faikin_master_mqtt_hvac
-                    - climate.faikin_basement_mqtt_hvac
+              - if:
+                  - condition: state
+                    entity_id: input_boolean.master_hvac_automation
+                    state: "on"
+                then:
+                  - action: climate.turn_off
+                    target:
+                      entity_id: climate.faikin_master_mqtt_hvac
+              - if:
+                  - condition: state
+                    entity_id: input_boolean.basement_hvac_automation
+                    state: "on"
+                then:
+                  - action: climate.turn_off
+                    target:
+                      entity_id: climate.faikin_basement_mqtt_hvac
 
           # Priority 2: Vacation Mode - Auto mode at away temperature
           - conditions:
@@ -106,52 +138,138 @@ automation:
                 entity_id: input_boolean.vacation_mode
                 state: "on"
             sequence:
-              - action: climate.set_temperature
-                target:
-                  entity_id:
-                    - climate.faikin_living_mqtt_hvac
-                    - climate.faikin_master_mqtt_hvac
-                    - climate.faikin_basement_mqtt_hvac
-                    - climate.faikin_guest_mqtt_hvac
-                data:
-                  hvac_mode: auto
-                  temperature: "{{ states('input_number.away_temperature') | float(70) }}"
+              - if:
+                  - condition: state
+                    entity_id: input_boolean.living_room_hvac_automation
+                    state: "on"
+                then:
+                  - action: climate.set_temperature
+                    target:
+                      entity_id: climate.faikin_living_mqtt_hvac
+                    data:
+                      hvac_mode: auto
+                      temperature: "{{ states('input_number.away_temperature') | float(70) }}"
+              - if:
+                  - condition: state
+                    entity_id: input_boolean.master_hvac_automation
+                    state: "on"
+                then:
+                  - action: climate.set_temperature
+                    target:
+                      entity_id: climate.faikin_master_mqtt_hvac
+                    data:
+                      hvac_mode: auto
+                      temperature: "{{ states('input_number.away_temperature') | float(70) }}"
+              - if:
+                  - condition: state
+                    entity_id: input_boolean.basement_hvac_automation
+                    state: "on"
+                then:
+                  - action: climate.set_temperature
+                    target:
+                      entity_id: climate.faikin_basement_mqtt_hvac
+                    data:
+                      hvac_mode: auto
+                      temperature: "{{ states('input_number.away_temperature') | float(70) }}"
+              - if:
+                  - condition: state
+                    entity_id: input_boolean.guest_hvac_automation
+                    state: "on"
+                then:
+                  - action: climate.set_temperature
+                    target:
+                      entity_id: climate.faikin_guest_mqtt_hvac
+                    data:
+                      hvac_mode: auto
+                      temperature: "{{ states('input_number.away_temperature') | float(70) }}"
 
           # Priority 3: Sleep Mode - Cool mode at sleep temperature
           - conditions:
               - condition: state
-                entity_id: binary_sensor.sleep_schedule
+                entity_id: binary_sensor.sleep_temperature_active
                 state: "on"
             sequence:
-              # Turn on bedroom units
-              - action: climate.set_temperature
-                target:
-                  entity_id:
-                    - climate.faikin_master_mqtt_hvac
-                    - climate.faikin_guest_mqtt_hvac
-                data:
-                  hvac_mode: cool
-                  temperature: "{{ states('input_number.sleep_temperature') | float(68) }}"
+              # Bedroom units in cool mode
+              - if:
+                  - condition: state
+                    entity_id: input_boolean.master_hvac_automation
+                    state: "on"
+                then:
+                  - action: climate.set_temperature
+                    target:
+                      entity_id: climate.faikin_master_mqtt_hvac
+                    data:
+                      hvac_mode: cool
+                      temperature: "{{ states('input_number.sleep_temperature') | float(68) }}"
+              - if:
+                  - condition: state
+                    entity_id: input_boolean.guest_hvac_automation
+                    state: "on"
+                then:
+                  - action: climate.set_temperature
+                    target:
+                      entity_id: climate.faikin_guest_mqtt_hvac
+                    data:
+                      hvac_mode: cool
+                      temperature: "{{ states('input_number.sleep_temperature') | float(68) }}"
               # Turn off other units to save energy
-              - action: climate.turn_off
-                target:
-                  entity_id:
-                    - climate.faikin_living_mqtt_hvac
-                    - climate.faikin_basement_mqtt_hvac
+              - if:
+                  - condition: state
+                    entity_id: input_boolean.living_room_hvac_automation
+                    state: "on"
+                then:
+                  - action: climate.turn_off
+                    target:
+                      entity_id: climate.faikin_living_mqtt_hvac
+              - if:
+                  - condition: state
+                    entity_id: input_boolean.basement_hvac_automation
+                    state: "on"
+                then:
+                  - action: climate.turn_off
+                    target:
+                      entity_id: climate.faikin_basement_mqtt_hvac
 
         # Priority 4 (Default): Awake Mode - Auto mode at awake temperature
         default:
-          - action: climate.set_temperature
-            target:
-              entity_id:
-                - climate.faikin_living_mqtt_hvac
-                - climate.faikin_basement_mqtt_hvac
-                - climate.faikin_guest_mqtt_hvac
-            data:
-              hvac_mode: auto
-              temperature: "{{ states('input_number.awake_temperature') | float(71) }}"
-          # Turn off other units to save energy
-          - action: climate.turn_off
-            target:
-              entity_id:
-                - climate.faikin_master_mqtt_hvac
+          - if:
+              - condition: state
+                entity_id: input_boolean.living_room_hvac_automation
+                state: "on"
+            then:
+              - action: climate.set_temperature
+                target:
+                  entity_id: climate.faikin_living_mqtt_hvac
+                data:
+                  hvac_mode: auto
+                  temperature: "{{ states('input_number.awake_temperature') | float(71) }}"
+          - if:
+              - condition: state
+                entity_id: input_boolean.basement_hvac_automation
+                state: "on"
+            then:
+              - action: climate.set_temperature
+                target:
+                  entity_id: climate.faikin_basement_mqtt_hvac
+                data:
+                  hvac_mode: auto
+                  temperature: "{{ states('input_number.awake_temperature') | float(71) }}"
+          - if:
+              - condition: state
+                entity_id: input_boolean.guest_hvac_automation
+                state: "on"
+            then:
+              - action: climate.set_temperature
+                target:
+                  entity_id: climate.faikin_guest_mqtt_hvac
+                data:
+                  hvac_mode: auto
+                  temperature: "{{ states('input_number.awake_temperature') | float(71) }}"
+          - if:
+              - condition: state
+                entity_id: input_boolean.master_hvac_automation
+                state: "on"
+            then:
+              - action: climate.turn_off
+                target:
+                  entity_id: climate.faikin_master_mqtt_hvac


### PR DESCRIPTION
## Summary

- Replaces the single `hvac_automation_enabled` toggle with four per-unit booleans (`living_room_hvac_automation`, `master_hvac_automation`, `basement_hvac_automation`, `guest_hvac_automation`) so each HVAC unit can be independently automated
- Adds `binary_sensor.sleep_temperature_active` (23:30–06:00) — a 1-hour-inset window within the sleep schedule (22:30–07:00) — so sleep temperatures kick in an hour after bedtime and awake temperatures resume an hour before wake-up
- Removes the "Air Quality & System Info" dashboard card, which referenced undefined sensors (`hvac_learning_heat_time`, `hvac_learning_cool_time`, `basement_hvac_ac_target`)

## Test plan

- [ ] Reload HA config and verify no errors on the 4 new `input_boolean` entities
- [ ] Verify `binary_sensor.sleep_temperature_active` appears and transitions at 23:30 / 06:00
- [ ] Toggle each per-unit automation on/off and confirm only that unit is affected
- [ ] Confirm HVAC dashboard shows 4 individual toggles and no Air Quality card